### PR TITLE
Update attrs dependency version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.12"
-attr = "^0.3.2"
+attrs = ">=21.3.0"
 boto3 = "^1.35.76"
 aiohttp = "^3.11.10"
 pycognito = "^2024.5.1"


### PR DESCRIPTION
you're using attrs.define, so you need attrs = ">=21.3.0" not attr, which is a different package that shawods the attr namespace in some instances.